### PR TITLE
Batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ We used Python 3.9.9 and [PyTorch](https://pytorch.org/) 1.10.1 to train and tes
 
     pip install git+https://github.com/openai/whisper.git 
 
+To update the package to the latest version of this repository, please run:
+
+    pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
+
 It also requires the command-line tool [`ffmpeg`](https://ffmpeg.org/) to be installed on your system, which is available from most package managers:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ result = model.transcribe("audio.mp3")
 print(result["text"])
 ```
 
-Internally, the `transcribe()` method reads the entire file and processes the audio with a sliding 30-second window, performing autoregressive sequence-to-sequence predictions on each window.
+Internally, the `transcribe()` method reads the entire file and processes the audio with a sliding 30-second window, performing autoregressive sequence-to-sequence predictions on each window. The `transcribe()` method also supports lists of files, which will be processed in-parallel as a batch and a list of results will be returned. This can be more efficient than processing many clips serially on a GPU.
+
+```python
+results = model.transcribe(["audio1.mp3", "audio2.mp3"])
+```
+
+In the case where audio clips are different lengths, whisper will dynamically reduce its internal batch size as shorter clips are completed.
 
 Below is an example usage of `whisper.detect_language()` and `whisper.decode()` which provide lower-level access to the model.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Internally, the `transcribe()` method reads the entire file and processes the au
 
 ```python
 results = model.transcribe(["audio1.mp3", "audio2.mp3"])
+print(results[0]['text'])
+print(results[1]['text'])
 ```
 
 In the case where audio clips are different lengths, whisper will dynamically reduce its internal batch size as shorter clips are completed.

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -700,8 +700,9 @@ class DecodingTask:
         self.decoder.reset()
         tokenizer: Tokenizer = self.tokenizer
         n_audio: int = mel.shape[0]
-
+        
         audio_features: Tensor = self._get_audio_features(mel)  # encoder forward pass
+
         if type(self.initial_tokens) == list:
             # if batched, then stack prompts together in batch dimension
             tokens = [list(token) for token in self.initial_tokens]
@@ -711,12 +712,12 @@ class DecodingTask:
 
         # detect language if requested, overwriting the language token
         languages, language_probs = self._detect_language(audio_features, tokens)
+
         if self.options.task == "lang_id":
             return [
                 DecodingResult(audio_features=features, language=language, language_probs=probs)
                 for features, language, probs in zip(audio_features, languages, language_probs)
             ]
-
         # repeat the audio & text tensors by the group size, for beam search or best-of-n sampling
         audio_features = audio_features.repeat_interleave(self.n_group, dim=0)
         tokens = tokens.repeat_interleave(self.n_group, dim=0).to(audio_features.device)

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -704,20 +704,20 @@ class DecodingTask:
 
         def pad_tokens(batch_tokens: List[List[int]]) -> List[List[int]]:
             # pad all token sequences to the length of the largest sequence with nospeech tokens
-            print(f'batch tokens to pad: {batch_tokens}')
+            #print(f'batch tokens to pad: {batch_tokens}')
             target_len = max([len(l) for l in batch_tokens])
             new_batch_tokens = []
             for entry in batch_tokens:
                 disparity = target_len - len(entry)
                 prefix = [50256]*disparity
                 new_batch_tokens.append(prefix + entry)
-            print(f'new batched tokens after padding: {new_batch_tokens}')
+            #print(f'new batched tokens after padding: {new_batch_tokens}')
             return new_batch_tokens
 
         audio_features: Tensor = self._get_audio_features(mel)  # encoder forward pass
         # TODO: get prompt tokens in self.initial_tokens, pad, and batch along zero dimension
         if type(self.initial_tokens) == list:
-            print(f'initial_tokens: {self.initial_tokens}')
+            #print(f'initial_tokens: {self.initial_tokens}')
             tokens = [list(token) for token in self.initial_tokens]
             tokens = pad_tokens(tokens)
             tokens: Tensor = torch.tensor(tokens)

--- a/whisper/model.py
+++ b/whisper/model.py
@@ -214,10 +214,10 @@ class Whisper(nn.Module):
         )
 
     def embed_audio(self, mel: torch.Tensor):
-        return self.encoder.forward(mel)
+        return self.encoder(mel)
 
     def logits(self, tokens: torch.Tensor, audio_features: torch.Tensor):
-        return self.decoder.forward(tokens, audio_features)
+        return self.decoder(tokens, audio_features)
 
     def forward(self, mel: torch.Tensor, tokens: torch.Tensor) -> Dict[str, torch.Tensor]:
         return self.decoder(tokens, self.encoder(mel))

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -235,6 +235,7 @@ class Tokenizer:
     @property
     @lru_cache()
     def non_speech_tokens(self) -> Tuple[int]:
+        # NOTE: This is a way to suppress artifacts of the training data like captions etc.
         """
         Returns the list of tokens to suppress in order to avoid any speaker tags or non-speech
         annotations, to prevent sampling texts that are not actually spoken in the audio, e.g.

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -1,3 +1,4 @@
+import time
 import argparse
 import os
 import warnings
@@ -279,15 +280,15 @@ def batch_transcribe(
     **decode_options,
 ):
     """
-    Transcribe an audio file using Whisper
+    Transcribe multiple audio files in parallel using the batch dimension of the Whisper model
 
     Parameters
     ----------
     model: Whisper
         The Whisper model instance
 
-    audio: Union[str, np.ndarray, torch.Tensor]
-        The path to the audio file to open, or the audio waveform
+    audio: Union[List[str], List[np.ndarray], List[torch.Tensor]]
+        The list of paths to the audio files to open, or the audio waveforms
 
     verbose: bool
         Whether to display the text being decoded to the console. If True, displays all the details,
@@ -317,7 +318,7 @@ def batch_transcribe(
 
     Returns
     -------
-    A dictionary containing the resulting text ("text") and segment-level details ("segments"), and
+    A list of dictionaries containing the resulting text ("text") and segment-level details ("segments"), and
     the spoken language ("language"), which is detected when `decode_options["language"]` is None.
     """
     batch_size = len(audio)

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -1,4 +1,3 @@
-import time
 import argparse
 import os
 import warnings

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -24,8 +24,8 @@ def optional_float(string):
 
 
 def compression_ratio(text) -> float:
-    return len(text) / len(zlib.compress(text.encode("utf-8")))
-
+    text_bytes = text.encode("utf-8")
+    return len(text_bytes) / len(zlib.compress(text_bytes))
 
 def format_timestamp(seconds: float, always_include_hours: bool = False, decimal_marker: str = '.'):
     assert seconds >= 0, "non-negative timestamp expected"


### PR DESCRIPTION
Opening PR for merging and conflict resolution. The `batch-processing` branch introduces a single major modification to the behavior of the `model.transcribe()` method, which can now accept a list of audio file paths rather than a single audio file path. These files are packed into the batch dimension of the model for transcription, allowing users to achieve better GPU utilization. Audio clips can be different lengths and the internal batch size will be reduced as the transcription of sorter files is completed.

Remaining issues to address:

- [ ] Test behavior of different transcription options for failure
- [x] Modify docstring of batch_transcribe method to reflect modifications
- [ ] Verify behavior of decode options for different clips
- [x] Include some benchmarking results